### PR TITLE
Ajout de l'affichage de la distance des courses

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,6 +566,14 @@
             font-weight: 500;
         }
 
+        .course-distance {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: var(--accent);
+            font-size: 0.85rem;
+        }
+
         .course-type {
             font-size: 0.85rem;
             color: var(--light-gold);
@@ -1671,6 +1679,7 @@
                                 <div class="course-name">${course.nom || ""}</div>
                                 <div class="course-meta">
                                     <div class="participant-count">${participantsCount} participant${participantsCount > 1 ? 's' : ''}</div>
+                                    <div class="course-distance"><i class="fas fa-route"></i> ${course.distance || ""}</div>
                                     <div class="course-type">${course.type || "Plat"}</div>
                                 </div>
                             </div>
@@ -1772,6 +1781,11 @@
                             <i class="fas fa-calendar-alt"></i>
                             <div class="info-label">Date</div>
                             <div class="info-value">${coursesLoader.formatDateDMY(window.currentDate)}</div>
+                        </div>
+                        <div class="info-item">
+                            <i class="fas fa-route"></i>
+                            <div class="info-label">Distance</div>
+                            <div class="info-value">${course.distance || "Non spécifiée"}</div>
                         </div>
                         <div class="info-item">
                             <i class="fas fa-users"></i>


### PR DESCRIPTION
Cette pull request ajoute l'affichage de la distance des courses de deux façons:

1. Dans les cartes de courses sur la page d'accueil, avec une icône de route (fa-route)
2. Dans les détails de chaque course, avec un élément dédié dans la grille d'informations

Ces modifications permettent d'avoir une vision plus complète des caractéristiques des courses directement dans l'interface, sans avoir besoin de chercher cette information ailleurs.

Modifications:
- Ajout du style CSS pour l'affichage de la distance
- Modification du template HTML pour les cartes de course
- Ajout d'un nouvel élément d'information dans la section détaillée des courses